### PR TITLE
Fix grafana_dashboard value to automate JSON import

### DIFF
--- a/grafana/dashboards.yaml
+++ b/grafana/dashboards.yaml
@@ -5,7 +5,7 @@ metadata:
   name: knative-eventing-dashboards
   namespace: knative-eventing
   labels:
-    grafana_dashboard: "true"
+    grafana_dashboard: "1"
 data:
   knative-eventing-broker.json: |
     {
@@ -1986,7 +1986,7 @@ metadata:
   name: knative-serving-dashboards
   namespace: knative-serving
   labels:
-    grafana_dashboard: "true"
+    grafana_dashboard: "1"
 data:
   knative-revision-cpu-memory-metrics.json: |
     {


### PR DESCRIPTION
Fixes #14

## Proposed Changes

- 🐛 Set `grafana_dashboard: "1"` to automatically load Knative dashboards

### Additional info

The following _values.yaml_ was used:

```yaml
kube-state-metrics:
  metricLabelsAllowlist:
   - pods=[*]
   - deployments=[app.kubernetes.io/name,app.kubernetes.io/component,app.kubernetes.io/instance]
prometheus:
  prometheusSpec:
    serviceMonitorSelectorNilUsesHelmValues: false
    podMonitorSelectorNilUsesHelmValues: false
grafana:
  sidecar:
    dashboards:
      enabled: true
      searchNamespace: ALL
```